### PR TITLE
Potential fix for code scanning alert no. 3: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/python-package.yml
+++ b/.github/workflows/python-package.yml
@@ -3,6 +3,9 @@
 
 name: Python package
 
+permissions:
+  contents: read
+
 on:
   push:
     branches: [ master ]


### PR DESCRIPTION
Potential fix for [https://github.com/ChristopheHD/enocean/security/code-scanning/3](https://github.com/ChristopheHD/enocean/security/code-scanning/3)

To fix the issue, we need to add a `permissions` block to the workflow. This block should specify the minimum permissions required for the workflow to function correctly. Based on the actions used in the workflow, the `contents: read` permission is sufficient for most steps, while additional permissions (e.g., `pull-requests: write`) may be required if the workflow interacts with pull requests.

The `permissions` block can be added at the root level of the workflow to apply to all jobs or at the job level for more granular control. In this case, adding it at the root level is appropriate since all jobs in the workflow appear to require similar permissions.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
