### PR TITLE
Potential fix for code scanning alert no. 1: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/python-publish.yml
+++ b/.github/workflows/python-publish.yml
@@ -2,6 +2,9 @@
 # For more information see: https://help.github.com/en/actions/language-and-framework-guides/using-python-with-github-actions#publishing-to-package-registries
 
 name: Upload Python Package
+permissions:
+  contents: read
+  packages: write
 
 on:
   release:


### PR DESCRIPTION
Potential fix for [https://github.com/ChristopheHD/enocean/security/code-scanning/1](https://github.com/ChristopheHD/enocean/security/code-scanning/1)

To fix the issue, add a `permissions` block at the root of the workflow file. This block will explicitly define the minimal permissions required for the workflow to function. Since the workflow involves checking out the repository and publishing a package, it needs `contents: read` to read the repository and `packages: write` to upload the package. These permissions should be sufficient for the workflow's purpose.

The `permissions` block should be added immediately after the `name` field in the workflow file.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
