### PR TITLE
Fix: Use lxml parser for EEP files

### DIFF
--- a/enocean/protocol/eep.py
+++ b/enocean/protocol/eep.py
@@ -22,10 +22,10 @@ class EEP(object):
         try:
             if version_info[0] > 2:
                 with open(eep_path, 'r', encoding='UTF-8') as xml_file:
-                    self.soup = BeautifulSoup(xml_file.read(), "html.parser")
+                    self.soup = BeautifulSoup(xml_file.read(), "lxml")
             else:
                 with open(eep_path, 'r') as xml_file:
-                    self.soup = BeautifulSoup(xml_file.read(), "html.parser")
+                    self.soup = BeautifulSoup(xml_file.read(), "lxml")
             self.init_ok = True
             self.__load_xml()
         except IOError:

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,2 +1,3 @@
 pyserial>=3.5
 beautifulsoup4>=4.13.3
+lxml>=4.5.0

--- a/setup.py
+++ b/setup.py
@@ -29,4 +29,5 @@ setup(
         'enum-compat>=0.0.2',
         'pyserial>=3.0',
         'beautifulsoup4>=4.3.2',
+        'lxml>=4.5.0',
     ])


### PR DESCRIPTION
The html.parser in BeautifulSoup4 has become stricter in recent versions, and now fails to parse the EEP.xml file correctly.

This commit switches the parser to `lxml`, which is more robust for XML files. The `lxml` library is also added as a dependency.

This fixes issue #15.