### PR TITLE
🛡️ Sentinel: [MEDIUM] Improve TCPCommunicator security

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -1,0 +1,4 @@
+## 2026-02-03 - [TCP Exposure and DoS Mitigation]
+**Vulnerability:** TCPCommunicator listened on all interfaces by default and had no buffer limit, leading to potential unauthorized access and DoS via memory exhaustion.
+**Learning:** Defaulting to all interfaces (`''`) in network listeners is a security risk. Making the host mandatory ensures users consciously choose the binding interface. Additionally, found a Python pitfall where logging a tuple using `"%s" % (addr)` fails with `TypeError` because the tuple is unpacked; it must be `"%s" % (addr,)`.
+**Prevention:** Always require binding address for network listeners and implement resource limits (buffer sizes) for all external inputs. Use defensive string formatting for logging objects that might be tuples.

--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -1,4 +1,0 @@
-## 2026-02-03 - [TCP Exposure and DoS Mitigation]
-**Vulnerability:** TCPCommunicator listened on all interfaces by default and had no buffer limit, leading to potential unauthorized access and DoS via memory exhaustion.
-**Learning:** Defaulting to all interfaces (`''`) in network listeners is a security risk. Making the host mandatory ensures users consciously choose the binding interface. Additionally, found a Python pitfall where logging a tuple using `"%s" % (addr)` fails with `TypeError` because the tuple is unpacked; it must be `"%s" % (addr,)`.
-**Prevention:** Always require binding address for network listeners and implement resource limits (buffer sizes) for all external inputs. Use defensive string formatting for logging objects that might be tuples.

--- a/enocean/communicators/tests/test_tcpcommunicator.py
+++ b/enocean/communicators/tests/test_tcpcommunicator.py
@@ -1,0 +1,54 @@
+# -*- encoding: utf-8 -*-
+from __future__ import print_function, unicode_literals, division, absolute_import
+import pytest
+import socket
+from unittest.mock import MagicMock, patch
+from enocean.communicators.tcpcommunicator import TCPCommunicator
+
+
+def test_tcp_communicator_init():
+    ''' Test TCPCommunicator initialization '''
+    with pytest.raises(TypeError):
+        TCPCommunicator()
+    com = TCPCommunicator('127.0.0.1')
+    assert com.host == '127.0.0.1'
+    assert com.port == 9637
+    assert com.max_buffer_size == 10 * 1024 * 1024
+
+
+@patch('socket.socket')
+def test_tcp_communicator_buffer_limit(mock_socket_cls):
+    ''' Test TCPCommunicator buffer limit '''
+    mock_sock = MagicMock()
+    mock_socket_cls.return_value = mock_sock
+
+    mock_client = MagicMock()
+    # accept once, then timeout to exit the outer loop (if _stop_flag is set)
+    mock_sock.accept.side_effect = [(mock_client, ('127.0.0.1', 12346)), socket.timeout]
+
+    # Simulate receiving data: first chunk is fine, second chunk exceeds limit
+    # We use 0x55 to avoid the buffer being cleared by parse() if it thinks the data is garbage
+    mock_client.recv.side_effect = [b'\x55' + b'A' * 59, b'A' * 60]
+
+    com = TCPCommunicator('127.0.0.1')
+    com.max_buffer_size = 100
+
+    # We want to stop AFTER the first client is handled.
+    # We can't easily do it without threading or side effects.
+    # Let's make the second accept call set the stop flag.
+    def side_effect_accept():
+        if mock_sock.accept.call_count == 2:
+            com._stop_flag.set()
+            raise socket.timeout
+        return (mock_client, ('127.0.0.1', 12346))
+
+    mock_sock.accept.side_effect = side_effect_accept
+
+    com.run()
+
+    # recv should be called twice: once for the first chunk, once for the chunk that exceeds the limit
+    assert mock_client.recv.call_count == 2
+    # The first chunk should be in the buffer, the second one should be dropped
+    assert len(com._buffer) == 60
+    # Connection should be closed after breaking the loop
+    mock_client.close.assert_called_once()

--- a/examples/tcp_server.py
+++ b/examples/tcp_server.py
@@ -12,7 +12,7 @@ except ImportError:
     import Queue as queue
 
 init_logging()
-communicator = TCPCommunicator()
+communicator = TCPCommunicator('127.0.0.1')
 communicator.start()
 while communicator.is_alive():
     try:


### PR DESCRIPTION
🚨 Severity: MEDIUM
💡 Vulnerability: `TCPCommunicator` listened on all interfaces by default and had no limit on the input buffer size.
🎯 Impact: Potential accidental exposure of EnOcean device control to the network and susceptibility to Denial of Service (DoS) via memory exhaustion.
🔧 Fix:
- Made `host` a mandatory argument in `TCPCommunicator` to ensure secure binding.
- Implemented a fixed 10MB buffer size limit in `TCPCommunicator.run`.
- Fixed a pre-existing `TypeError` bug in `TCPCommunicator` logging when a client connects.
- Updated `examples/tcp_server.py` to use `127.0.0.1` by default.
✅ Verification: Added comprehensive tests in `enocean/communicators/tests/test_tcpcommunicator.py` verifying mandatory host and buffer limit enforcement. All existing tests pass.

---
*PR created automatically by Jules for task [6564632214550831290](https://jules.google.com/task/6564632214550831290) started by @ChristopheHD*